### PR TITLE
Allow promotion on diagonal moves of pion

### DIFF
--- a/lib/chess/move/destination.ex
+++ b/lib/chess/move/destination.ex
@@ -35,8 +35,26 @@ defmodule Chess.Move.Destination do
               Keyword.put(squares, :"#{to}", move.figure)
             ]
 
-          # valid promotion
+          # valid promotion without opponent
           x_route == 0 && figure_at_the_end == nil && last_line_for_pion?(color, to) ->
+            squares = Keyword.delete(squares, :"#{from}")
+            [
+              false,
+              false,
+              Keyword.put(squares, :"#{to}", %Figure{color: color, type: promotion})
+            ]
+
+          # valid promotion with opponent
+          x_route == -1 && figure_at_the_end != nil && last_line_for_pion?(color, to) ->
+            squares = Keyword.delete(squares, :"#{from}")
+            [
+              false,
+              false,
+              Keyword.put(squares, :"#{to}", %Figure{color: color, type: promotion})
+            ]
+
+          # valid promotion with opponent
+          x_route == 1 && figure_at_the_end != nil && last_line_for_pion?(color, to) ->
             squares = Keyword.delete(squares, :"#{from}")
             [
               false,

--- a/lib/chess/move/destination.ex
+++ b/lib/chess/move/destination.ex
@@ -45,16 +45,7 @@ defmodule Chess.Move.Destination do
             ]
 
           # valid promotion with opponent
-          x_route == -1 && figure_at_the_end != nil && last_line_for_pion?(color, to) ->
-            squares = Keyword.delete(squares, :"#{from}")
-            [
-              false,
-              false,
-              Keyword.put(squares, :"#{to}", %Figure{color: color, type: promotion})
-            ]
-
-          # valid promotion with opponent
-          x_route == 1 && figure_at_the_end != nil && last_line_for_pion?(color, to) ->
+          (x_route == -1 || x_route == 1) && figure_at_the_end != nil && last_line_for_pion?(color, to) ->
             squares = Keyword.delete(squares, :"#{from}")
             [
               false,

--- a/test/chess/promotion_test.exs
+++ b/test/chess/promotion_test.exs
@@ -1,0 +1,48 @@
+defmodule Chess.PromotionTest do
+  use ExUnit.Case
+
+  alias Chess.Game
+
+  test "promotion to queen - 1" do
+    game = Game.new("r3qbnr/ppP2k1p/8/8/8/6p1/PP5P/RNBQ1KpR w - - 0 18")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-c8")
+
+    assert current_fen == "r1Q1qbnr/pp3k1p/8/8/8/6p1/PP5P/RNBQ1KpR b - - 0 18"
+  end
+
+  test "promotion to queen - 2" do
+    game = Game.new("rnPq1bnr/ppP2kpp/8/8/8/8/PPP1K2P/RNBQ1ppR w - - 0 12")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-b8", "q")
+
+    assert current_fen == "rQPq1bnr/pp3kpp/8/8/8/8/PPP1K2P/RNBQ1ppR b - - 0 12"
+  end
+
+  test "promotion to queen - 3" do
+    game = Game.new("rnPq1bnr/ppP2kpp/8/8/8/8/PPP1K2P/RNBQ1ppR w - - 0 12")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-d8", "q")
+
+    assert current_fen == "rnPQ1bnr/pp3kpp/8/8/8/8/PPP1K2P/RNBQ1ppR b - - 0 12"
+  end
+
+  test "promotion to knight - 1" do
+    game = Game.new("r3qbnr/ppP2k1p/8/8/8/6p1/PP5P/RNBQ1KpR w - - 0 18")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-c8", "n")
+
+    assert current_fen == "r1N1qbnr/pp3k1p/8/8/8/6p1/PP5P/RNBQ1KpR b - - 0 18"
+  end
+
+  test "promotion to knight - 2" do
+    game = Game.new("rnPq1bnr/ppP2kpp/8/8/8/8/PPP1K2P/RNBQ1ppR w - - 0 12")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-b8", "n")
+
+    assert current_fen == "rNPq1bnr/pp3kpp/8/8/8/8/PPP1K2P/RNBQ1ppR b - - 0 12"
+  end
+
+  test "promotion to knight - 3" do
+    game = Game.new("rnPq1bnr/ppP2kpp/8/8/8/8/PPP1K2P/RNBQ1ppR w - - 0 12")
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(game, "c7-d8", "n")
+
+    assert current_fen == "rnPN1bnr/pp3kpp/8/8/8/8/PPP1K2P/RNBQ1ppR b - - 0 12"
+  end
+
+end


### PR DESCRIPTION
Hi @kortirso,

even tough a lot of time has passed since your last commit, it's still a great library. Thank you for creating it!

I realised the pions promotion only worked when going to the last square in a direct line. If you'd go there on a diagonal path by taking an opponent, the pion wouldn't promote.

I added the necessary cases and a couple of tests.

Best,
Malte