### PR TITLE
Fix en passant move

### DIFF
--- a/lib/chess/move/destination.ex
+++ b/lib/chess/move/destination.ex
@@ -21,10 +21,6 @@ defmodule Chess.Move.Destination do
           x_route == 0 && figure_at_the_end != nil ->
             {:error, "There are barrier for pion at the and of move"}
 
-          # invalid attack without opponent
-          x_route != 0 && figure_at_the_end == nil ->
-            {:error, "Pion must attack for diagonal move"}
-
           # valid en_passant attack
           x_route != 0 && figure_at_the_end == nil && to == en_passant ->
             beated_pion = pion_beated_en_passant(color, to)
@@ -34,6 +30,10 @@ defmodule Chess.Move.Destination do
               false,
               Keyword.put(squares, :"#{to}", move.figure)
             ]
+
+          # invalid attack without opponent
+          x_route != 0 && figure_at_the_end == nil ->
+            {:error, "Pion must attack for diagonal move"}
 
           # valid promotion without opponent
           x_route == 0 && figure_at_the_end == nil && last_line_for_pion?(color, to) ->

--- a/lib/chess/move/destination.ex
+++ b/lib/chess/move/destination.ex
@@ -24,6 +24,7 @@ defmodule Chess.Move.Destination do
           # valid en_passant attack
           x_route != 0 && figure_at_the_end == nil && to == en_passant ->
             beated_pion = pion_beated_en_passant(color, to)
+            squares = Keyword.delete(squares, :"#{from}")
             squares = Keyword.delete(squares, :"#{beated_pion}")
             [
               true,

--- a/test/chess/en_passant_test.exs
+++ b/test/chess/en_passant_test.exs
@@ -1,0 +1,22 @@
+defmodule Chess.EnPassantTest do
+  use ExUnit.Case
+
+  alias Chess.Game
+
+  setup_all do
+    game = Game.new("rnbqkbnr/p1p1pppp/8/3pP3/1p6/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1")
+    {:ok, game: game}
+  end
+
+  test "valid en passant", state do
+    {:ok, %Game{squares: _, current_fen: current_fen, status: _, check: _}} = Game.play(state[:game], "e5-d6")
+
+    assert current_fen == "rnbqkbnr/p1p1pppp/3P4/8/1p6/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+  end
+
+  test "invalid en passant", state do
+    {:error, message} = Game.play(state[:game], "e5-f6")
+
+    assert message == "Pion must attack for diagonal move"
+  end
+end


### PR DESCRIPTION
Hi,

doing an en passant move just failed with `{:error, "Pion must attack for diagonal move"}`. Changing the order of the checks solved the problem but left the board with an additional pawn. This was fixed by the third commit.

What do you think? 

Best,
Malte