### PR TITLE
Fix MatchError in `make_virtual_move/4`

### DIFF
--- a/lib/chess/move/end_move.ex
+++ b/lib/chess/move/end_move.ex
@@ -113,17 +113,17 @@ defmodule Chess.Move.EndMove do
 
       defp make_virtual_move(figures, move, game, current_position) do
         Enum.any?(figures, fn {_, from, to} ->
-          {:ok, virtual_game} =
-            %Game{
-              squares: move.squares,
-              current_fen: Position.new(move, current_position) |> Position.to_fen(),
-              history: [],
-              status: :check,
-              check: current_position.active
-            }
-            |> Game.play("#{from}-#{to}")
-
-          virtual_game.status == :playing
+          case %Game{
+                 squares: move.squares,
+                 current_fen: Position.new(move, current_position) |> Position.to_fen(),
+                 history: [],
+                 status: :check,
+                 check: current_position.active
+               }
+               |> Game.play("#{from}-#{to}") do
+            {:ok, virtual_game} -> virtual_game.status == :playing
+            {:error, _reason} -> false
+          end
         end)
       end
 

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -59,6 +59,24 @@ defmodule Chess.GameTest do
     assert message == "This move is invalid, king is under attack"
   end
 
+  test "make_virtual_move handles error tuple during check validation" do
+    # This position triggers a MatchError in make_virtual_move/4 if error tuples
+    # from Game.play are not handled properly during check validation.
+    # Previously crashed with: ** (MatchError) no match of right hand side value:
+    # {:error, "There is barrier at square e1"}
+    #
+    # The bug occurred during virtual move simulation when checking if a piece
+    # could block or capture an attacker. The fix handles {:error, _} tuples
+    # gracefully instead of crashing.
+    fen = "3rk2r/ppp1bppp/2n5/8/6b1/5q2/PPP2P1P/R2RK3 b k - 11 18"
+    game = Game.new(fen)
+
+    # This move should succeed without crashing - it's actually checkmate
+    {:ok, game} = Game.play(game, "f3-h1")
+
+    assert %Game{status: :completed, check: "b"} = game
+  end
+
   test "Kasparov-Topalov, 1999", state do
     {:ok, game} = Game.play(state[:game], "e2-e4")
     {:ok, game} = Game.play(game, "d7-d6")


### PR DESCRIPTION
## Summary

`make_virtual_move/4` in `lib/chess/move/end_move.ex` crashes with `MatchError` when `Game.play/2` returns an error tuple during check validation.

## Reproducible Example

```elixir
# This crashes with MatchError instead of returning {:error, reason}
fen = "3rk2r/ppp1bppp/2n5/8/6b1/5q2/PPP2P1P/R2RK3 b k - 11 18"
game = Chess.Game.new(fen)
Chess.Game.play(game, "f3-h1")

# Result:
# ** (MatchError) no match of right hand side value: {:error, "There is barrier at square e1"}
#     (chess 0.4.3) lib/chess/move.ex:18: anonymous fn/3 in Chess.Move.make_virtual_move/4
```

## The Bug

In `lib/chess/move/end_move.ex` lines 114-128:

```elixir
defp make_virtual_move(figures, move, game, current_position) do
  Enum.any?(figures, fn {_, from, to} ->
    {:ok, virtual_game} =           # <-- This pattern match crashes if Game.play returns {:error, _}
      %Game{
        squares: move.squares,
        current_fen: Position.new(move, current_position) |> Position.to_fen(),
        history: [],
        status: :check,
        check: current_position.active
      }
      |> Game.play("#{from}-#{to}")

    virtual_game.status == :playing
  end)
end
```

## Suggested Fix

```elixir
defp make_virtual_move(figures, move, game, current_position) do
  Enum.any?(figures, fn {_, from, to} ->
    case %Game{
           squares: move.squares,
           current_fen: Position.new(move, current_position) |> Position.to_fen(),
           history: [],
           status: :check,
           check: current_position.active
         }
         |> Game.play("#{from}-#{to}") do
      {:ok, virtual_game} -> virtual_game.status == :playing
      {:error, _reason} -> false
    end
  end)
end
```

## Expected Behavior

`Chess.Game.play/2` should return `{:error, reason}` for invalid moves, not crash.

## Environment

- Chess library version: 0.4.3
- Elixir: 1.18.3


## Side note

You could play https://chess.dimamik.com to test your chess engine ;)